### PR TITLE
Add BFO-9000 keyboard layout

### DIFF
--- a/app/keyboardType/bfo9000.ts
+++ b/app/keyboardType/bfo9000.ts
@@ -1,0 +1,38 @@
+import { sameRowButLower } from "./utils"
+
+const row1 = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+    { x: 3, y: 0 },
+    { x: 4, y: 0 },
+    { x: 5, y: 0 },
+    { x: 6, y: 0 },
+    { x: 7, y: 0 },
+    { x: 8, y: 0 },
+    { x: 9, y: 0 },
+    // end of left side, begginning of right side
+    { x: 11, y: 0 },
+    { x: 12, y: 0 },
+    { x: 13, y: 0 },
+    { x: 14, y: 0 },
+    { x: 15, y: 0 },
+    { x: 16, y: 0 },
+    { x: 17, y: 0 },
+    { x: 18, y: 0 },
+]
+const row2 = sameRowButLower(row1)
+const row3 = sameRowButLower(row2)
+const row4 = sameRowButLower(row3)
+const row5 = sameRowButLower(row4)
+const row6 = sameRowButLower(row5)
+
+
+const positions: Position[] = [...row1, ...row2, ...row3, ...row4, ...row5, ...row6]
+
+export const bfo9000: KeyboardType = {
+    name: "BFO-9000",
+    positions,
+    spacing: 2.4,
+    keySize: 2.2,
+  };

--- a/app/keyboardType/bfo9000.ts
+++ b/app/keyboardType/bfo9000.ts
@@ -33,6 +33,6 @@ const positions: Position[] = [...row1, ...row2, ...row3, ...row4, ...row5, ...r
 export const bfo9000: KeyboardType = {
     name: "BFO-9000",
     positions,
-    spacing: 2.4,
-    keySize: 2.2,
+    spacing: 2.18,
+    keySize: 1.8,
   };

--- a/app/keyboardType/bfo9000.ts
+++ b/app/keyboardType/bfo9000.ts
@@ -10,8 +10,8 @@ const row1 = [
     { x: 6, y: 0 },
     { x: 7, y: 0 },
     { x: 8, y: 0 },
-    { x: 9, y: 0 },
     // end of left side, begginning of right side
+    { x: 10, y: 0 },
     { x: 11, y: 0 },
     { x: 12, y: 0 },
     { x: 13, y: 0 },

--- a/app/keyboardType/list.ts
+++ b/app/keyboardType/list.ts
@@ -1,6 +1,7 @@
 import { validatePhysicalLayout } from "../service/physical";
 import { moonlander } from "./moonlander";
 import { piantor } from "./piantor";
+import { bfo9000 } from "./bfo9000";
 
 import planc from "../physical/planc.json";
 import ansi104 from "../physical/ansi104.json";
@@ -26,6 +27,7 @@ for (const l of jsonLayouts) {
 export const keyboardTypes: KeyboardType[] = [
   piantor,
   moonlander,
+  bfo9000,
   //layouts from json
   ...jsonLayouts,
 ];


### PR DESCRIPTION
tested locally and confirmed working: https://alextremblay.github.io/keyfab/

only issue is that the BFO-9000 is such a big keyboard, it spills out of its container:

![image](https://github.com/jaroslaw-weber/keyfab/assets/23367954/a199a968-cb16-4457-9ae9-4866fc599752)

This was easily fixed by updating the width of the layer element:

![image](https://github.com/jaroslaw-weber/keyfab/assets/23367954/7088b304-c429-4552-8c1b-403f61763405)

Got me to thinking: it would be really nice if `KeyboardType` from `keyfab/app/types/KeyboardType.types.ts` had a `minWidth` property or something